### PR TITLE
use safe-eval instead of built in eval for maximum security

### DIFF
--- a/lib/bypasser.js
+++ b/lib/bypasser.js
@@ -4,6 +4,7 @@ const URL      = require('url');
 const Promise  = require('bluebird');
 const rp       = require('request-promise');
 const extend   = require('extend');
+const safeEval = require('safe-eval');
 const helpers  = require('./helpers');
 
 const DELAY = 5*1000;
@@ -289,7 +290,7 @@ class CloudflareBypasser {
   }
 
   static solveChallenge(code = '') {
-    return eval(code);
+    return safeEval(code);
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "extend": "^3.0.1",
+    "prettyjson": "^1.2.1",
     "request": "^2.85.0",
     "request-promise": "^4.2.2",
-    "prettyjson": "^1.2.1"
+    "safe-eval": "^0.4.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
While yes it's highly unlikely that Cloudflare would do anything malicious I still think it would be better to use safeEval than the vanilla eval just for safety